### PR TITLE
Fix "Get a loan" link

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -41,7 +41,7 @@ const Profile = () => {
                            ? (
                               <div>
                                  <p>You have no loans!</p>
-                                 <Link to="/loans/available" className="text-sm text-yellow-700 hover:text-blue-600">Get a loan</Link>
+                                 <Link to="/money/loans/available" className="text-sm text-yellow-700 hover:text-blue-600">Get a loan</Link>
                               </div>
                            )
                            : (


### PR DESCRIPTION
The get a loan link shown if the user doesn't have any loans points to the wrong URL and shows a blank page. Updating it from "/loans/available" to "/money/loans/available" fixes this issue.